### PR TITLE
Indirect objects are resolved once.

### DIFF
--- a/pypdf2_structures/arg_processing.py
+++ b/pypdf2_structures/arg_processing.py
@@ -11,7 +11,7 @@ _OUTPUT_EXTENSION_IN_LIST = [_OUTPUT_EXTENSION]
 
 class StructureType(Enum):
 	"""
-	This enumeration contains the types of PDF object structure that this
+	This enumeration contains the types of PyPDF2 object structure that this
 	package can explore: PDF fields and PDF pages.
 	"""
 	FIELD = 0

--- a/pypdf2_structures/arg_processing.py
+++ b/pypdf2_structures/arg_processing.py
@@ -1,8 +1,6 @@
 from argparse import ArgumentParser
 from enum import Enum
 from pathlib import Path
-from pdf_obj_struct import write_pdf_obj_struct
-from PyPDF2 import PdfFileReader
 
 
 _INPUT_EXTENSION = ".pdf"
@@ -57,8 +55,7 @@ def make_parser(struct_type):
 
 	parser.add_argument("-d", "--depth", type=int, default=0,
 		help="Limit of the recursion depth that the algorithm can reach. If 0\
-		or less, no limit is set, and PyPDF2's indirect objects will not be\
-		resolved. Defaults to 0.")
+		or less, no limit is set. Defaults to 0.")
 
 	parser.add_argument("-o", "--output", type=Path,
 		help="Path to the .txt output file. If set to \"console\", the object\
@@ -89,8 +86,8 @@ def process_arguments(args, struct_type):
 			[2]: (pathlib.Path) the path to the output file
 
 	Raises:
-		ValueError: if the path to the file to explore or struct_type is
-			incorrect
+		ValueError: if the path to the file to explore does not exist or does
+		not have extension .pdf.
 	"""
 	if struct_type == StructureType.FIELD:
 		o_file_stem_end = "_field_objects"
@@ -123,8 +120,8 @@ def process_arguments(args, struct_type):
 			output_path = None
 
 	elif output_path.is_dir():
-		output_path = output_path/\
-			_make_default_output_file_name(input_path, o_file_stem_end)
+		output_path = output_path/_make_default_output_file_name(
+			input_path, o_file_stem_end)
 
 	elif output_path.suffixes != _OUTPUT_EXTENSION_IN_LIST:
 		output_path = output_path.with_suffix(_OUTPUT_EXTENSION)

--- a/pypdf2_structures/ind_obj_solver.py
+++ b/pypdf2_structures/ind_obj_solver.py
@@ -1,0 +1,92 @@
+from PyPDF2.generic import IndirectObject
+
+
+def _make_ind_obj_id(ind_obj):
+	"""
+	Creates a tuple that represents a PyPDF2 IndirectObject ID. The first
+	element is attribute idnum; the second is attribute generation.
+
+	Args:
+		ind_obj (PyPDF2.generic.IndirectObject): an indirect object
+
+	Returns:
+		tuple:
+			[0]: ind_obj.idnum (int)
+			[1]: ind_obj.generation (int)
+	"""
+	return (ind_obj.idnum, ind_obj.generation)
+
+
+class _IndObjRecord:
+
+	def __init__(self, ind_obj, solved_obj_used):
+		self._ind_obj = ind_obj
+		self._solved_obj_used = solved_obj_used
+		self._solved_obj = ind_obj.getObject()
+		self._solved_type = type(self._solved_obj)
+
+	@property
+	def ind_obj(self):
+		return self._ind_obj
+
+	@property
+	def solved_obj(self):
+		return self._solved_obj
+
+	@property
+	def solved_obj_used(self):
+		return self._solved_obj_used
+
+	@solved_obj_used.setter
+	def solved_obj_used(self, used):
+		self._solved_obj_used = used
+
+	@property
+	def solved_type(self):
+		return self._solved_type
+
+
+class IndObjSolver:
+
+	def __init__(self):
+		# Keys: ID tuples
+		# Values: _IndObjRecord instances
+		self._ind_obj_records = dict()
+
+	def get_resolved_type(self, ind_obj):
+		ind_obj_id = _make_ind_obj_id(ind_obj)
+		record = self._ind_obj_records.get(ind_obj_id)
+
+		if record is None:
+			record = _IndObjRecord(ind_obj, False)
+			self._ind_obj_records[ind_obj_id] = record
+
+		return record.solved_type
+
+	@staticmethod
+	def is_ind_obj(obj):
+		"""
+		Determines whether the given object is a PyPDF2 IndirectObject.
+
+		Args:
+			obj: any object
+
+		Returns:
+			bool: True if obj in an IndirectObject, False otherwise
+		"""
+		return isinstance(obj, IndirectObject)
+
+	def solve_ind_obj(self, ind_obj):
+		ind_obj_id = _make_ind_obj_id(ind_obj)
+		record = self._ind_obj_records.get(ind_obj_id)
+		was_solved = True
+
+		if record is None:
+			record = _IndObjRecord(ind_obj, True)
+			self._ind_obj_records[ind_obj_id] = record
+
+		elif not record.solved_obj_used:
+			was_solved = False
+			record.solved_obj_used = True
+
+		return record.solved_obj, was_solved

--- a/pypdf2_structures/ind_obj_solver.py
+++ b/pypdf2_structures/ind_obj_solver.py
@@ -11,8 +11,8 @@ def _make_ind_obj_id(ind_obj):
 
 	Returns:
 		tuple:
-			[0]: ind_obj.idnum (int)
-			[1]: ind_obj.generation (int)
+			[0] (int): ind_obj.idnum
+			[1] (int): ind_obj.generation
 	"""
 	return (ind_obj.idnum, ind_obj.generation)
 
@@ -47,13 +47,32 @@ class _IndObjRecord:
 
 
 class IndObjSolver:
+	"""
+	This class resolves PyPDF2 IndirectObject instances and keeps a record of
+	them. The objects are marked as resolved or not.
+	"""
 
 	def __init__(self):
+		"""
+		The constructor of IndObjSolver creates an empty record of resolved
+		objects.
+		"""
 		# Keys: ID tuples
 		# Values: _IndObjRecord instances
 		self._ind_obj_records = dict()
 
 	def get_resolved_type(self, ind_obj):
+		"""
+		Resolves an indirect objet to determine its type. If the object is
+		unknown to this instance, it is recorded, but in either case, it is not
+		marked as resolved.
+
+		Args:
+			ind_obj (PyPDF2.generic.IndirectObject): an indirect object
+
+		Returns:
+			type: the resolved type of ind_obj
+		"""
 		ind_obj_id = _make_ind_obj_id(ind_obj)
 		record = self._ind_obj_records.get(ind_obj_id)
 
@@ -77,6 +96,20 @@ class IndObjSolver:
 		return isinstance(obj, IndirectObject)
 
 	def solve_ind_obj(self, ind_obj):
+		"""
+		Resolves an indirect object to provide the resolved object. If the
+		object is unknown to this instance, it is recorded. In either case,
+		the object is marked as resolved.
+
+		Args:
+			ind_obj (PyPDF2.generic.IndirectObject): an indirect object
+
+		Returns:
+			tuple:
+				[0] (object): the resolved object
+				[1] (bool): True if the object has already been resolved, False
+					otherwise
+		"""
 		ind_obj_id = _make_ind_obj_id(ind_obj)
 		record = self._ind_obj_records.get(ind_obj_id)
 		was_solved = True

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -10,7 +10,7 @@ from PyPDF2.generic import\
 	BooleanObject,\
 	DictionaryObject
 
-from .ind_obj_solver import IndObjSolver
+from ind_obj_solver import IndObjSolver
 
 
 _DLST = (dict, list, set, tuple)

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -82,20 +82,7 @@ def _obj_is_a_page(obj):
 		return False
 
 
-def _rslv_pdf_ind_object(obj):
-	if isinstance(obj, IndirectObject):
-		return obj.getObject()
-
-	else:
-		return obj
-
-
-def _return_arg(obj):
-	return obj
-
-
-def write_pdf_obj_struct(struct, w_stream, write_types=False,
-		rslv_ind_objs=False, depth_limit=0):
+def write_pdf_obj_struct(struct, w_stream, write_types=False,depth_limit=0):
 	"""
 	Writes a PDF object structure in a file stream. The indentation indicates
 	which objects are contained in others. The stream's mode must be "a",
@@ -109,10 +96,6 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 			structure's representation
 		write_types (bool): If True, this function will write the contained
 			objects' type in the stream. Defaults to False.
-		rslv_ind_objs (bool): If True, the indirect objects found in the
-			structure will be resolved. Defaults to False. WARNING! Setting
-			this parameter to True can make the function exceed the maximum
-			recursion depth.
 		depth_limit (int): a limit to the recursion depth. If it is set to 0
 			or less, no limit is enforced. Defaults to 0.
 
@@ -125,7 +108,6 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,
 			+ "\"a\", \"a+\", \"r+\", \"w\" or \"w+\".")
 
 	obj_str_fnc = _obj_and_type_to_str if write_types else str
-	ind_obj_fnc = _rslv_pdf_ind_object if rslv_ind_objs else _return_arg
 
 	if obj_is_a_dlst(struct):
 		w_stream.write(str(type(struct)) + _NEW_LINE)

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -82,7 +82,7 @@ def _obj_is_a_page(obj):
 		return False
 
 
-def write_pdf_obj_struct(struct, w_stream, write_types=False,depth_limit=0):
+def write_pdf_obj_struct(struct, w_stream, write_types=False, depth_limit=0):
 	"""
 	Writes a PDF object structure in a file stream. The indentation indicates
 	which objects are contained in others. The stream's mode must be "a",
@@ -120,6 +120,7 @@ def write_pdf_obj_struct(struct, w_stream, write_types=False,depth_limit=0):
 		depth_limit, obj_str_fnc)
 
 
+# Global variable for recursive function _write_pdf_obj_struct_rec
 resolved_objs = list()
 
 def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -1,8 +1,8 @@
 """
-This module allows to write a PDF object structure in a file stream. An object
-structure consists of containers (dictionaries, lists, sets and tuples)
-embedded in one another and other objects. This module also works on
-structures that do not contain PDF objects.
+This module allows to write a PyPDF2 object structure in a file stream. An
+object structure consists of containers (dictionaries, lists, sets and tuples)
+embedded in one another and other objects. This module also works on structures
+that do not contain PyPDF2 objects.
 """
 
 

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -10,7 +10,7 @@ from PyPDF2.generic import\
 	BooleanObject,\
 	DictionaryObject
 
-from ind_obj_solver import IndObjSolver
+from .ind_obj_solver import IndObjSolver
 
 
 _DLST = (dict, list, set, tuple)

--- a/pypdf2_structures/write_field_objects.py
+++ b/pypdf2_structures/write_field_objects.py
@@ -11,7 +11,7 @@ def _write_field_objs_in_stream(pdf_path, field_dict, w_stream, depth_limit):
 	w_stream.write("Objects in the fields of " + str(pdf_path) + "\n")
 
 	for mapping_name, field in field_dict.items():
-		w_stream.write("\n" + mapping_name + "\n")
+		w_stream.write("\nField " + mapping_name + "\n")
 		write_pdf_obj_struct(field, w_stream, depth_limit)
 
 

--- a/pypdf2_structures/write_field_objects.py
+++ b/pypdf2_structures/write_field_objects.py
@@ -1,6 +1,4 @@
-from argparse import ArgumentParser
 from arg_processing import make_parser, process_arguments, StructureType
-from pathlib import Path
 from pdf_obj_struct import write_pdf_obj_struct
 from PyPDF2 import PdfFileReader
 
@@ -10,8 +8,7 @@ def _write_field_objs_in_stream(pdf_path, field_dict, w_stream, depth_limit):
 
 	for mapping_name, field in field_dict.items():
 		w_stream.write("\n" + mapping_name + "\n")
-		write_pdf_obj_struct(field, w_stream,
-			True, depth_limit>0, depth_limit)
+		write_pdf_obj_struct(field, w_stream, True, depth_limit)
 
 
 if __name__ == "__main__":
@@ -31,7 +28,7 @@ if __name__ == "__main__":
 
 	if output_path is None:
 		from sys import stdout
-		_write_field_objs_in_console(input_path, fields, stdout, depth_limit)
+		_write_field_objs_in_stream(input_path, fields, stdout, depth_limit)
 
 	else:
 		with output_path.open(mode="w", encoding="utf8") as output_stream:

--- a/pypdf2_structures/write_field_objects.py
+++ b/pypdf2_structures/write_field_objects.py
@@ -8,7 +8,7 @@ def _write_field_objs_in_stream(pdf_path, field_dict, w_stream, depth_limit):
 
 	for mapping_name, field in field_dict.items():
 		w_stream.write("\n" + mapping_name + "\n")
-		write_pdf_obj_struct(field, w_stream, True, depth_limit)
+		write_pdf_obj_struct(field, w_stream, depth_limit)
 
 
 if __name__ == "__main__":

--- a/pypdf2_structures/write_field_objects.py
+++ b/pypdf2_structures/write_field_objects.py
@@ -1,6 +1,10 @@
-from arg_processing import make_parser, process_arguments, StructureType
-from pdf_obj_struct import write_pdf_obj_struct
 from PyPDF2 import PdfFileReader
+
+from arg_processing import\
+	make_parser,\
+	process_arguments,\
+	StructureType
+from pdf_obj_struct import write_pdf_obj_struct
 
 
 def _write_field_objs_in_stream(pdf_path, field_dict, w_stream, depth_limit):

--- a/pypdf2_structures/write_page_objects.py
+++ b/pypdf2_structures/write_page_objects.py
@@ -1,6 +1,10 @@
-from arg_processing import make_parser, process_arguments, StructureType
-from pdf_obj_struct import write_pdf_obj_struct
 from PyPDF2 import PdfFileReader
+
+from arg_processing import\
+	make_parser,\
+	process_arguments,\
+	StructureType
+from pdf_obj_struct import write_pdf_obj_struct
 
 
 def _write_page_objs_in_stream(pdf_path, pages, w_stream, depth_limit):

--- a/pypdf2_structures/write_page_objects.py
+++ b/pypdf2_structures/write_page_objects.py
@@ -9,7 +9,7 @@ def _write_page_objs_in_stream(pdf_path, pages, w_stream, depth_limit):
 	for i in range(len(pages)):
 		page = pages[i]
 		w_stream.write("\n\nPAGE " + str(i) + "\n")
-		write_pdf_obj_struct(page, w_stream, True, depth_limit)
+		write_pdf_obj_struct(page, w_stream, depth_limit)
 
 
 if __name__ == "__main__":

--- a/pypdf2_structures/write_page_objects.py
+++ b/pypdf2_structures/write_page_objects.py
@@ -1,6 +1,4 @@
-from argparse import ArgumentParser
 from arg_processing import make_parser, process_arguments, StructureType
-from pathlib import Path
 from pdf_obj_struct import write_pdf_obj_struct
 from PyPDF2 import PdfFileReader
 
@@ -11,7 +9,7 @@ def _write_page_objs_in_stream(pdf_path, pages, w_stream, depth_limit):
 	for i in range(len(pages)):
 		page = pages[i]
 		w_stream.write("\n\nPAGE " + str(i) + "\n")
-		write_pdf_obj_struct(page, w_stream, True, depth_limit>0, depth_limit)
+		write_pdf_obj_struct(page, w_stream, True, depth_limit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Subsequent occurrences of indirect objects are replaced with their string representation (example: "IndirectObject(280, 0)").
* Thus, infinite recursion is still prevented.
* A recursion depth limit still can be specified. However, its omission does not prevent the resolution of indirect objects.
* Function write_pdf_obj_struct always writes data types.