### PR TITLE
Recursion stop condition corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ pip install -r requirements.txt
 
 Elle prend comme arguments une structure d'objets et un flux d'écriture de
 fichier (mode `a`, `a+`, `r+`, `w` ou `w+`) pour produire une représentation
-textuelle des objets. Un troisième paramètre permet de limiter la profondeur de
+textuelle de la structure. L'indentation indique quels objets sont contenus
+dans les autres. Un troisième paramètre permet de limiter la profondeur de
 l'exploration de la structure. Les objets au-delà de la profondeur limite ne
-sont pas inclus dans le fichier de sortie et sont représentés par `[...]`. Il y
-a une exception toutefois: si l'objet au niveau de profondeur juste après la
-limite n'est pas un conteneur, il est inscrit dans le flux.
+sont pas inclus dans le flux et sont représentés par `[...]`. Il y a une
+exception toutefois: si l'objet au niveau de profondeur juste après la limite
+n'est pas un conteneur, il est inscrit dans le flux.
 
 `PyPDF2` utilise des objets indirects (type `IndirectObject`) comme références
 à des objets qui n'ont pas encore été chargés en mémoire. La fonction
@@ -63,11 +64,12 @@ pip install -r requirements.txt
 ### Function `write_pdf_obj_struct`
 
 It takes an object structure and a file writing stream (mode `a`, `a+`, `r+`,
-`w` ou `w+`) as arguments to make a text representation of the objets. A third
-parameter allows to limit the depth of the structure's exploration. The objects
-beyond the depth limit are not included in the output file and are represented
-by `[...]`. There is an exception though: if the objet at the depth level just
-after the limit is not a container, it is written in the stream.
+`w` ou `w+`) as arguments to make a text representation of the structure. The
+indentation indicates which objects are contained in others. A third parameter
+allows to limit the depth of the structure's exploration. The objects beyond
+the depth limit are not included in the stream and are represented by `[...]`.
+There is an exception though: if the objet at the depth level just after the
+limit is not a container, it is written in the stream.
 
 `PyPDF2` uses indirect objects (type `IndirectObject`) as references to objects
 that have not been loaded in memory. Function `write_pdf_obj_struct`resolves

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 ## Français
 
 Dans la bibliothèque [PyPDF2](https://pypi.org/project/PyPDF2/), les pages et
-les champs des fichiers PDF sont des structures d'objets complexes. Ce dépôt
-permet d'écrire dans des fichers texte une représentation de ces structures.
+les champs des fichiers PDF sont des structures d'objets complexes. Une
+structure d'objets consiste en des conteneurs (dictionaires, listes, *sets* et
+tuples) comportant d'autres conteneurs et d'autres types d'objets. Ce dépôt
+permet d'écrire dans des fichers texte une représentation de ces structures,
+même celles qui ne contiennent pas d'objets de `PyPDF2`.
 
 Utilisez cette commande pour installer les dépendances du dépôt.
 
@@ -17,10 +20,10 @@ pip install -r requirements.txt
 Elle prend comme arguments une structure d'objets et un flux d'écriture de
 fichier (mode `a`, `a+`, `r+`, `w` ou `w+`) pour produire une représentation
 textuelle des objets. Un troisième paramètre permet de limiter la profondeur de
-l'exploration de la structure. Quand la profondeur limite est atteinte, les
-objets au-delà ne sont pas inclus dans le fichier de sortie. Toutefois, si
-l'objet au niveau de profondeur suivant n'est ni un dictionnaire, une liste, un
-*set* ni un tuple, il est inscrit dans le flux même si la limite est atteinte.
+l'exploration de la structure. Les objets au-delà de la profondeur limite ne
+sont pas inclus dans le fichier de sortie et sont représentés par `[...]`. Il y
+a une exception toutefois: si l'objet au niveau de profondeur juste après la
+limite n'est pas un conteneur, il est inscrit dans le flux.
 
 `PyPDF2` utilise des objets indirects (type `IndirectObject`) comme références
 à des objets qui n'ont pas encore été chargés en mémoire. La fonction
@@ -45,8 +48,11 @@ python write_page_objects.py -h
 ## English
 
 In library [PyPDF2](https://pypi.org/project/PyPDF2/), the pages and fields of
-PDF files are complex object structures. This repository allows to write a
-representation of those structures in text files.
+PDF files are complex object structures. An object structure consists of
+containers (dictionaries, lists, sets and tuples) that hold other containers
+and other object types. This repository allows to write a representation of
+those structures in text files, even those that do not contain `PyPDF2`
+objects.
 
 Use this command to install the repository's dependencies.
 
@@ -58,10 +64,10 @@ pip install -r requirements.txt
 
 It takes an object structure and a file writing stream (mode `a`, `a+`, `r+`,
 `w` ou `w+`) as arguments to make a text representation of the objets. A third
-parameter allows to limit the depth of the structure's exploration. When the
-depth limit is reached, the objects beyond are not included in the output file.
-However, if the object at the next depth level is not a dictionary, a list, a
-set or a tuple, it is written in the stream even though the limit is reached.
+parameter allows to limit the depth of the structure's exploration. The objects
+beyond the depth limit are not included in the output file and are represented
+by `[...]`. There is an exception though: if the objet at the depth level just
+after the limit is not a container, it is written in the stream.
 
 `PyPDF2` uses indirect objects (type `IndirectObject`) as references to objects
 that have not been loaded in memory. Function `write_pdf_obj_struct`resolves

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ pip install -r requirements.txt
 
 Elle prend comme arguments une structure d'objets et un flux d'écriture de
 fichier (mode `a`, `a+`, `r+`, `w` ou `w+`) pour produire une représentation
-textuelle de la structure. L'indentation indique quels objets sont contenus
-dans les autres. Un troisième paramètre permet de limiter la profondeur de
+textuelle de la structure. L'indentation indique quels objets en contiennent
+d'autres. Un troisième paramètre permet de limiter la profondeur de
 l'exploration de la structure. Les objets au-delà de la profondeur limite ne
 sont pas inclus dans le flux et sont représentés par `[...]`. Il y a une
 exception toutefois: si l'objet au niveau de profondeur juste après la limite
@@ -65,7 +65,7 @@ pip install -r requirements.txt
 
 It takes an object structure and a file writing stream (mode `a`, `a+`, `r+`,
 `w` ou `w+`) as arguments to make a text representation of the structure. The
-indentation indicates which objects are contained in others. A third parameter
+indentation indicates which objects contain other ones. A third parameter
 allows to limit the depth of the structure's exploration. The objects beyond
 the depth limit are not included in the stream and are represented by `[...]`.
 There is an exception though: if the objet at the depth level just after the

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ pip install -r requirements.txt
 Elle prend comme arguments une structure d'objets et un flux d'écriture de
 fichier (mode `a`, `a+`, `r+`, `w` ou `w+`) pour produire une représentation
 textuelle des objets. Un troisième paramètre permet de limiter la profondeur de
-l'exploration de la structure. Si la profondeur limite est atteinte, les objets
-au-delà ne seront pas inclus dans le fichier de sortie.
+l'exploration de la structure. Quand la profondeur limite est atteinte, les
+objets au-delà ne sont pas inclus dans le fichier de sortie. Toutefois, si
+l'objet au niveau de profondeur suivant n'est ni un dictionnaire, une liste, un
+*set* ni un tuple, il est inscrit dans le flux même si la limite est atteinte.
 
 `PyPDF2` utilise des objets indirects (type `IndirectObject`) comme références
 à des objets qui n'ont pas encore été chargés en mémoire. La fonction
@@ -56,9 +58,10 @@ pip install -r requirements.txt
 
 It takes an object structure and a file writing stream (mode `a`, `a+`, `r+`,
 `w` ou `w+`) as arguments to make a text representation of the objets. A third
-parameter allows to limit the depth of the structure's exploration. If the
-depth limit is reached, the objects beyond will not be included in the output
-file.
+parameter allows to limit the depth of the structure's exploration. When the
+depth limit is reached, the objects beyond are not included in the output file.
+However, if the object at the next depth level is not a dictionary, a list, a
+set or a tuple, it is written in the stream even though the limit is reached.
 
 `PyPDF2` uses indirect objects (type `IndirectObject`) as references to objects
 that have not been loaded in memory. Function `write_pdf_obj_struct`resolves

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -48,8 +48,8 @@ def _make_tabs(n):
 
 
 def _next_rec_allowed(item, rec_depth, depth_limit):
-	return depth_limit<=0\
-		or rec_depth<=depth_limit\
+	return depth_limit <= 0\
+		or rec_depth < depth_limit\
 		or not obj_is_a_dlst(item)
 
 

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -47,10 +47,10 @@ def _make_tabs(n):
 	return _TAB * n
 
 
-def _next_rec_allowed(item, rec_depth, depth_limit):
+def _next_rec_allowed(item_is_dlst, rec_depth, depth_limit):
 	return depth_limit <= 0\
 		or rec_depth < depth_limit\
-		or not obj_is_a_dlst(item)
+		or not item_is_dlst
 
 
 def _obj_and_type_to_str(obj):
@@ -130,6 +130,7 @@ def write_pdf_obj_struct(struct, w_stream, depth_limit=0):
 
 def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 		depth_limit, ind_obj_solver):
+	w_stream.write(str(rec_depth))
 	tabs = _make_tabs(rec_depth)
 	rec_depth += 1
 
@@ -158,7 +159,8 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 				line = tabs + _PAGE_REF
 				w_stream.write(line)
 
-			elif _next_rec_allowed(item, rec_depth, depth_limit):
+			elif _next_rec_allowed(
+					issubclass(item_type, _DLST), rec_depth, depth_limit):
 				_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 					depth_limit, ind_obj_solver)
 
@@ -178,7 +180,8 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 				line = tabs + _PAGE_REF
 				w_stream.write(line)
 
-			elif _next_rec_allowed(value, rec_depth, depth_limit):
+			elif _next_rec_allowed(
+					issubclass(value_type, _DLST), rec_depth, depth_limit):
 				_write_pdf_obj_struct_rec(value, w_stream, rec_depth,
 					depth_limit, ind_obj_solver)
 
@@ -198,7 +201,8 @@ def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 				line = tabs + _PAGE_REF
 				w_stream.write(line)
 
-			elif _next_rec_allowed(item, rec_depth, depth_limit):
+			elif _next_rec_allowed(
+					issubclass(item_type, _DLST), rec_depth, depth_limit):
 				_write_pdf_obj_struct_rec(item, w_stream, rec_depth,
 					depth_limit, ind_obj_solver)
 

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -1,8 +1,8 @@
 """
 This module allows to write a PyPDF2 object structure in a file stream. An
 object structure consists of containers (dictionaries, lists, sets and tuples)
-embedded in one another and other objects. This module also works on structures
-that do not contain PyPDF2 objects.
+that hold other containers and other object types. This module also works on
+structures that do not contain PyPDF2 objects.
 """
 
 
@@ -98,9 +98,12 @@ def write_pdf_obj_struct(struct, w_stream, depth_limit=0):
 	"""
 	Writes a PDF object structure in a file stream. The indentation indicates
 	which objects are contained in others. The stream's mode must be "a",
-	"a+", "r+", "w" or "w+". If argument struct is not a dictionary, a list,
-	a set or a tuple, this function will only write one line representing that
-	object.
+	"a+", "r+", "w" or "w+". If argument struct is not a container, this
+	function will only write one line representing that object. It is possible
+	to limit the depth of the structure's exploration. The objects beyond the
+	depth limit are not included in the stream and are represented by "[...]".
+	There is an exception though: if the objet at the depth level just after
+	the limit is not a container, it is written in the stream.
 
 	Args:
 		struct: any object. Can be a container or not.

--- a/pypdf2_structures/pdf_obj_struct.py
+++ b/pypdf2_structures/pdf_obj_struct.py
@@ -49,7 +49,7 @@ def _make_tabs(n):
 
 def _next_rec_allowed(item_is_dlst, rec_depth, depth_limit):
 	return depth_limit <= 0\
-		or rec_depth < depth_limit\
+		or rec_depth <= depth_limit\
 		or not item_is_dlst
 
 
@@ -130,7 +130,6 @@ def write_pdf_obj_struct(struct, w_stream, depth_limit=0):
 
 def _write_pdf_obj_struct_rec(obj_to_write, w_stream, rec_depth,
 		depth_limit, ind_obj_solver):
-	w_stream.write(str(rec_depth))
 	tabs = _make_tabs(rec_depth)
 	rec_depth += 1
 


### PR DESCRIPTION
When module `pdf_obj_struct` determines whether a supplementary recursion must be allowed, it verifies the indirect objects' resolved type rather than type `IndirectObject`. `README.md` defines containers and the depth limit of object structure exploration.